### PR TITLE
Inner wake propagation now working

### DIFF
--- a/burgers.py
+++ b/burgers.py
@@ -12,7 +12,7 @@ def solve_burgers(eta, profile, gamma, beta_p, C, CFL, eta_tilde, t0, linear_sol
     tf_th = 300 # time required to develop N-wave for betap = 1
     tf = tf_th/beta_p # time required to display N-wave for generic betap, Eq. (39) Rafikov 2002
 
-    tf *= 2 # test doubling value
+    #tf *= 2 # test doubling value
 
     eta_min = -eta_tilde-np.sqrt(2*C*tf) - 3  # Eq. (18) Bollati et al. 2021
     eta_max = -eta_tilde+np.sqrt(2*C*tf) + 3
@@ -98,11 +98,8 @@ def solve_burgers(eta, profile, gamma, beta_p, C, CFL, eta_tilde, t0, linear_sol
     lapsed_time = 0
     counter = 0
     while lapsed_time < tf:
-    #while lapsed_time < tf + t0:
-    #while counter < 10:
         counter += 1
         dt = min(deta * CFL / (max(abs(solution[-1])) + 1e-8), 0.02)
-        #print('max of sol = ', max(abs(solution[-1])), ', dt = ', dt)
         time.append(time[-1]+dt)
         lapsed_time += dt
 
@@ -168,13 +165,13 @@ def solve_burgers(eta, profile, gamma, beta_p, C, CFL, eta_tilde, t0, linear_sol
         plt.show()
     
 
-    Nt = np.shape(solution)[1]
+    #Nt = np.shape(solution)[1]
 
-    solution_inner = np.zeros(solution.shape) # solution for r < Rp (and disc rotating counterclockwise)
-    eta_inner = - eta[::-1]
-    for i in range(Neta):
-        for j in range(Nt):
-            solution_inner[i,j] = solution[int(Neta-1-i),j]
+    #solution_inner = np.zeros(solution.shape) # solution for r < Rp (and disc rotating counterclockwise)
+    #eta_inner = - eta[::-1]
+    #for i in range(Neta):
+    #    for j in range(Nt):
+    #        solution_inner[i,j] = solution[int(Neta-1-i),j]
 
     # The following will put the linear solution into returned solution for Chi
     if False:
@@ -188,5 +185,5 @@ def solve_burgers(eta, profile, gamma, beta_p, C, CFL, eta_tilde, t0, linear_sol
         eta_inner = - eta[::-1]
         return total_time, eta, total_solution, eta_inner, solution_inner
 
-    return time, eta, solution, eta_inner, solution_inner
+    return time, eta, solution #, eta_inner, solution_inner
     

--- a/config.yaml
+++ b/config.yaml
@@ -1,22 +1,22 @@
 # DEFAULT parameter file for running wakeflow, HD 163296 parameters as example, set to run mcfost
 
 run_info:
-    name: "test_v_join"                          # give your run a name (results are saved a directory called this, don't use spaces)
-    system: "HD_163296"                          # name of the system you are modelling
+    name: "inner_wake"                           # give your run a name (results are saved a directory called this, don't use spaces)
+    system: "inner_wake"                         # name of the system you are modelling
 
 disk:
     m_star: 1.9                                  # mass of central star in solar masses
-    m_planet: [0.5, 1.0, 2.0, 4.0]               # mass of embedded planet(s) in Jupiter masses (list or float)
+    m_planet: [1.34]                              # mass of embedded planet(s) in Jupiter masses (list or float)
     r_outer: 500                                 # outer radius of disk in au
-    r_inner: 40                                  # inner radius of disk in au
-    r_planet: 210                                # orbital radius of embedded planet in au
-    r_ref: 235                                   # reference radius R0 for H/R
+    r_inner: 100                                 # inner radius of disk in au (does not apply for Cartesian grid)
+    r_planet: 270                                # orbital radius of embedded planet in au
+    r_ref: 270                                   # reference radius R0 for H/R
     r_c: 0                                       # critical radius for exponentially tapered density profile. set to 0 for power law
     q: 0.25                                      # q index, defined as c_s \propto R^{-q}
     p: 1.0                                       # p index, defined as rho \propto R^{-p} or \propto R^{-p}*\exp{-R/r_c}^{2-p}
-    hr: 0.15                                     # disc flaring H/R at R0
+    hr: 0.10                                     # disc flaring H/R at R0
     dens_ref: 1                                  # rho at R0 in g/cm^3, unimportant for mcfost as it rescales
-    cw_rotation: False                           # clockwise rotating disk (boolean)   # FALSE FOR HD 163
+    cw_rotation: True                            # CURRENTLY DOES NOTHING, you will get anticlockwise and be pleased about it :-) (bool)
 
 angles:
     inclination: -225                            # inclination of disk in degrees    (46.7)
@@ -25,8 +25,8 @@ angles:
 
 grid:
     type: "cartesian"                            # "cylindrical" or "cartesian" or "mcfost" -- must choose mcfost to write fits file
-    n_x: 200                                     # number of x grid points
-    n_y: 200                                     # number of y grid points
+    n_x: 400                                     # number of x grid points
+    n_y: 400                                     # number of y grid points
     n_r: 200                                     # number of r grid points
     n_phi: 160                                   # number of phi grid points
     n_z: 50                                      # number of z grid points
@@ -34,14 +34,14 @@ grid:
 
 plotting:
     make_midplane_plots: True                    # create midplane plots of velocity components and density
-    show_midplane_plots: False                   # show plots as code runs
-    show_teta_debug_plots: True                  # show t, eta space plots (including putting the linear solution into t,eta)
+    show_midplane_plots: True                    # show plots as code runs
+    show_teta_debug_plots: False                 # show t, eta space plots (including putting the linear solution into t,eta)
 
 results:
     include_planet: True                         # include perturbations from a planet? (lets you run an unperturbed disk) (bool)
     include_linear: True                         # include the results from the linear regime?
-    save_perturbations: False                    # save perturbations to npy file
-    save_total: False                            # save background + perturbations to npy file
+    save_perturbations: True                     # save perturbations to npy file
+    save_total: True                             # save background + perturbations to npy file
     write_FITS: False                            # write a FITS file to run in mcfost -- requires {grid.type: "mcfost"}
 
 # The following settings require an installation of mcfost and pymcfost
@@ -69,6 +69,6 @@ physical:
     damping_malpha: 0                            # artificial damping
 
 numerical:
-    CFL: 0.05                                    # CFL safety factor for Godunov scheme
+    CFL: 0.5                                     # CFL safety factor for Godunov scheme
     scale_box: 1.0                               # scale factor for linear regime box side length -- default is 1
-    scale_box_ang: 1.8                           # scale factor for linear regime box angular extend
+    scale_box_ang: 1.0                           # scale factor for linear regime box angular extend

--- a/grid.py
+++ b/grid.py
@@ -386,7 +386,7 @@ class Grid:
 
             # rho
             plt.close("all")
-            plt.contourf(self.X[:,0,0], self.Y[0,0,:], np.transpose(self.rho[:,z_slice,:]), levels=contour_lvls, vmin=-rho_max, vmax=rho_max, cmap='RdBu')
+            plt.contourf(self.X[:,0,0], self.Y[0,0,:], np.transpose(self.rho[:,z_slice,:]), levels=contour_lvls, vmin=-0.3*rho_max, vmax=0.3*rho_max, cmap='RdBu')
             plt.colorbar()
             plt.title(r"$\rho$")
             if save:

--- a/grid.py
+++ b/grid.py
@@ -69,7 +69,8 @@ class Grid:
             self.r = np.geomspace(self.p.r_inner, self.p.r_outer, self.p.n_r)
         else:
             self.r = np.linspace(self.p.r_inner, self.p.r_outer, self.p.n_r)    
-        self.phi = np.linspace(0, 2*np.pi, self.p.n_phi)
+        #self.phi = np.linspace(0, 2*np.pi, self.p.n_phi)
+        self.phi = np.linspace(-np.pi, np.pi, self.p.n_phi)
         self.z = np.linspace(0, self.height, self.p.n_z)
 
         self.PHI, self.Z, self.R = np.meshgrid(self.phi, self.z, self.r, indexing='ij')
@@ -396,12 +397,21 @@ class Grid:
         # Polar grid plots
         else:
 
+            ulen  = self.p.au
+            umass = self.p.m_solar
+            utime = np.sqrt(ulen**3 / (self.p.G_const * umass)) 
+            uvel  = ulen / utime / 1E5
+
             # v_r
             plt.close("all")
-            _, ax = plt.subplots(subplot_kw=dict(projection='polar'))
-            myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_r[:,z_slice,:], levels=contour_lvls, vmin=-vr_max, vmax=vr_max, cmap='RdBu')
-            ax.set_ylim(0, self.p.r_outer)
-            plt.colorbar(myplot, label=r"radial velocity [km/s]")
+            #_, ax = plt.subplots() #subplot_kw=dict(projection='polar'))
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_r[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-vr_max, vmax=vr_max, cmap='RdBu')
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_r[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-0.05, vmax=0.05, cmap='RdBu_r')
+            plt.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_r[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-0.05, vmax=0.05, cmap='RdBu_r')
+            #plt.colorbar()
+            #ax.set_ylim(0, self.p.r_outer)
+            plt.ylim(self.p.r_inner, self.p.r_outer)
+            #plt.colorbar(myplot, label=r"radial velocity [km/s]")
             if save:
                 plt.savefig(f'{savedir}/vr_z{z_slice}.pdf')
             if show:
@@ -409,10 +419,14 @@ class Grid:
 
             # v_phi
             plt.close("all")
-            _, ax = plt.subplots(subplot_kw=dict(projection='polar'))
-            myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_phi[:,z_slice,:], levels=contour_lvls, vmin=-vphi_max, vmax=vphi_max, cmap='RdBu')
-            ax.set_ylim(0, self.p.r_outer)
-            plt.colorbar(myplot)
+            #_, ax = plt.subplots() #subplot_kw=dict(projection='polar'))
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_phi[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-vphi_max, vmax=vphi_max, cmap='RdBu')
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_phi[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-0.05, vmax=0.05, cmap='RdBu_r')
+            plt.contourf(self.PHI[:,0,:], self.R[:,0,:], self.v_phi[:,z_slice,:]/uvel, levels=contour_lvls, vmin=-0.05, vmax=0.05, cmap='RdBu')
+            #ax.set_ylim(0, self.p.r_outer)
+            plt.ylim(self.p.r_inner, self.p.r_outer)
+            #plt.colorbar()
+            #plt.colorbar(myplot)
             plt.title(r"$v_{\phi}$")
             plt.title(r"$v_{\phi}$")
             if save:
@@ -422,10 +436,14 @@ class Grid:
 
             # rho
             plt.close("all")
-            _, ax = plt.subplots(subplot_kw=dict(projection='polar'))
-            myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.rho[:,z_slice,:], levels=contour_lvls, vmin=-rho_max, vmax=rho_max, cmap='RdBu')
-            ax.set_ylim(0, self.p.r_outer)
-            plt.colorbar(myplot)
+            _, ax = plt.subplots() #subplot_kw=dict(projection='polar'))
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.rho[:,z_slice,:], levels=contour_lvls, vmin=-rho_max, vmax=rho_max, cmap='RdBu')
+            #myplot = ax.contourf(self.PHI[:,0,:], self.R[:,0,:], self.rho[:,z_slice,:], levels=contour_lvls, vmin=-0.5, vmax=0.5, cmap='RdBu_r')
+            plt.contourf(self.PHI[:,0,:], self.R[:,0,:], self.rho[:,z_slice,:], levels=contour_lvls, vmin=-0.5, vmax=0.5, cmap='RdBu_r')
+            #ax.set_ylim(0, self.p.r_outer)
+            plt.ylim(self.p.r_inner, self.p.r_outer)
+            #plt.colorbar()
+            #plt.colorbar(myplot)
             plt.title(r"$\rho$")
             plt.title(r"$\rho$")
             if save:

--- a/mcfost_interface.py
+++ b/mcfost_interface.py
@@ -78,7 +78,7 @@ def make_mcfost_grid_data(parameters):
     working_dir = os.getcwd()
     os.chdir(f"{p.system}/{p.name}/mcfost/")
     subprocess.call(["rm", "-rf", "data_disk", "data_disk_old"])
-    subprocess.call(["mcfost", f"mcfost_{p.name}.para", "-disk_struct"], stdout=subprocess.DEVNULL)
+    subprocess.call(["mcfost", f"mcfost_{p.name}.para", "-disk_struct"]) #, stdout=subprocess.DEVNULL)
     os.chdir(working_dir)
 
     print("Done")
@@ -89,8 +89,8 @@ def read_mcfost_grid_data(parameters):
     p = parameters
     
     # reading disk data
-    with HiddenPrints():
-        mcfost_disk = Disc(f"./{p.system}/{p.name}/mcfost/")
+    #with HiddenPrints():
+    mcfost_disk = Disc(f"./{p.system}/{p.name}/mcfost/")
 
     # getting radii and heights
     r = mcfost_disk.r()[:, p.n_z:, :]

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,10 @@ class Parameters(Constants):
         self.p = float(config["disk"]["p"])
         self.hr = float(config["disk"]["hr"])
         self.rho_ref = float(config["disk"]["dens_ref"])
-        self.cw_rotation = bool(config["disk"]["cw_rotation"])
+
+        # override given rotation, only calculated anticlockwise
+        self.cw_rotation = False
+        self.user_cw_rotation = bool(config["disk"]["cw_rotation"])
 
         # angles parameters
         self.inclination = float(config["angles"]["inclination"])


### PR DESCRIPTION
Implemented changes to how the inner wake is calculated. Previously, the inner wake was a clone of the outer wake and flipped appropriately, based on the assumption that the radius of the inner and outer edge of the box is approximately equal, since the initial condition depends on this.

We are often desiring "large" linear box regimes (when H/R is not tiny), and so the aforementioned assumption isn't very good. This pull request contains an implementation where the difference in initial condition (radius on edge of box) is taken into account, and the inner and outer wakes are then both calculated separately before being mapped onto the disk.

Finally, to get this working I have sacrificed the calculation being able to be performed in both clockwise and anticlockwise rotating disks. It is not always anticlockwise. I intend on re-implementing this feature by rotating the results from an anticlockwise disk, but this has not been done yet.